### PR TITLE
README: configuration and sample MCP clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,14 @@ This will produce a debug binary under `target/debug/gnome-mcp-server`.
 
 ## Usage
 
-To use this MCP server, you need to configure an MCP client. The following is a list of general-purpose MCP clients known to work on Linux (in alphabetical order):
+To use this MCP server, you need to configure an MCP client. The configuration varies slightly from client to client, but this is the information that you will need:
+- Transport: `stdio`
+- Command: `/path/to/gnome-mcp-server/target/debug/gnome-mcp-server`
+- Args: `[]` (empty)
+
+## Clients
+
+The following is a list of general-purpose MCP clients known to work on Linux (in alphabetical order):
 
 | Name | Description | Open Source | Local LLM Support | Documentation |
 |------|-------------|-------------|-------------------|---------------|

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 Grant the AI octopus access to a portion of your desktop with a Model Context Protocol (MCP) server for the GNOME desktop.
 
+## Building
+
+To build the project, simply use:
+
+```bash
+cargo build
+```
+
+This will produce a debug binary under `target/debug/gnome-mcp-server`.
+
 ## Configuration
 
 By default, all tools and resources are enabled. Create a configuration file to customize behavior:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,22 @@ cargo build
 
 This will produce a debug binary under `target/debug/gnome-mcp-server`.
 
+## Usage
+
+To use this MCP server, you need to configure an MCP client. The following is a list of general-purpose MCP clients known to work on Linux (in alphabetical order):
+
+| Name | Description | Open Source | Local LLM Support | Documentation |
+|------|-------------|-------------|-------------------|---------------|
+| [goose](https://github.com/block/goose) | AI agent by Block (creators of Square) | ✅ | ✅ | [Docs](https://block.github.io/goose/docs/getting-started/using-extensions) |
+| [LM Studio](https://lmstudio.ai/) | Desktop app for running local LLMs | ❌ | ✅ | [Docs](https://lmstudio.ai/docs/app/plugins/mcp) |
+| [Speed of Light](https://github.com/zugaldia/speedoflight) | Native GNOME MCP client | ✅ | ✅ | [Docs](https://github.com/zugaldia/speedoflight/blob/main/README.md) |
+
+> **Know of other MCP clients that work on Linux?** Please submit a PR to add them to this table.
+
+Coding-specific agents like Claude Code, OpenAI Codex, Gemini CLI, VS Code Copilot, or Cursor also support MCP, but they typically rely on cloud models and have limited or no support for on-device LLMs.
+
+For additional MCP clients, see [this section](https://modelcontextprotocol.io/clients) in the official documentation.
+
 ## Configuration
 
 By default, all tools and resources are enabled. Create a configuration file to customize behavior:

--- a/README.md
+++ b/README.md
@@ -2,22 +2,22 @@
 
 Grant the AI octopus access to a portion of your desktop with a Model Context Protocol (MCP) server for the GNOME desktop.
 
-## Building
+## Installation
 
-To build the project, simply use:
+To build and install the MCP server to your system:
 
 ```bash
-cargo build
+cargo install --path .
 ```
 
-This will produce a debug binary under `target/debug/gnome-mcp-server`.
+The resulting binary will typically be under `~/.cargo/bin/gnome-mcp-server`.
 
 ## Usage
 
 To use this MCP server, you need to configure an MCP client. The configuration varies slightly from client to client, but this is the information that you will need:
 - Transport: `stdio`
-- Command: `/path/to/gnome-mcp-server/target/debug/gnome-mcp-server`
-- Args: `[]` (empty)
+- Command: `gnome-mcp-server` (assuming `~/.cargo/bin` is in your PATH)
+- Args: `[]` (empty list)
 
 ## Clients
 


### PR DESCRIPTION
This PR adds three new sections to the main README:
- Building: A quick note for those unfamiliar with Rust so that they know the right cargo command to build the binary.
- Usage: General settings to configure any MCP client. 
- Clients: a list of known clients for Linux. I'm sure there are more but these are the ones I have first hand experience with. Disclaimer: I am the author of the third client on the list (Speed of Light).

@bilelmoussaoui Feel free to push edits or changes as needed. 