### PR TITLE
GNOME shell 50 compat for screenshots

### DIFF
--- a/src/tools/screenshot.rs
+++ b/src/tools/screenshot.rs
@@ -13,7 +13,8 @@ tool_params! {
 
 impl ToolProvider for Screenshot {
     const NAME: &'static str = "take_screenshot";
-    const DESCRIPTION: &'static str = "Take a screenshot using the desktop portal";
+    const DESCRIPTION: &'static str =
+        "Take a screenshot using the desktop portal, falling back to GNOME Shell";
     type Params = ScreenshotParams;
 
     async fn execute_with_params(&self, params: Self::Params) -> Result<serde_json::Value> {
@@ -26,25 +27,98 @@ impl ToolProvider for Screenshot {
 }
 
 async fn take_screenshot_portal(interactive: bool) -> Result<String> {
-    match ScreenshotPortal::request()
+    let portal_result = match ScreenshotPortal::request()
         .interactive(interactive)
         .send()
-        .await?
-        .response()
+        .await
     {
-        Ok(response) => {
-            let uri = response.uri();
-            if interactive {
-                Ok(format!(
-                    "Interactive screenshot completed. File saved to: {uri}"
-                ))
-            } else {
-                Ok(format!("Screenshot taken. File saved to: {uri}"))
+        Ok(request) => match request.response() {
+            Ok(response) => {
+                let uri = response.uri();
+                if interactive {
+                    Ok(format!(
+                        "Interactive screenshot completed. File saved to: {uri}"
+                    ))
+                } else {
+                    Ok(format!("Screenshot taken. File saved to: {uri}"))
+                }
             }
-        }
+            Err(error) => Err(anyhow::anyhow!(
+                "Screenshot was cancelled or failed {}",
+                error
+            )),
+        },
         Err(error) => Err(anyhow::anyhow!(
             "Screenshot was cancelled or failed {}",
             error
         )),
+    };
+
+    match portal_result {
+        Ok(result) => Ok(result),
+        Err(portal_error) => {
+            let shell_result = if interactive {
+                take_interactive_screenshot_shell().await
+            } else {
+                take_screenshot_shell().await
+            };
+
+            shell_result.map_err(|shell_error| {
+                anyhow::anyhow!(
+                    "Portal screenshot failed: {portal_error}; GNOME Shell fallback failed: {shell_error}"
+                )
+            })
+        }
+    }
+}
+
+async fn take_screenshot_shell() -> Result<String> {
+    let connection = zbus::Connection::session().await?;
+    let proxy = zbus::Proxy::new(
+        &connection,
+        "org.gnome.Shell.Screenshot",
+        "/org/gnome/Shell/Screenshot",
+        "org.gnome.Shell.Screenshot",
+    )
+    .await?;
+
+    let filename = format!(
+        "/tmp/gnome-mcp-screenshot-{}.png",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)?
+            .as_secs()
+    );
+
+    let response = proxy
+        .call_method("Screenshot", &(false, false, filename.as_str()))
+        .await?;
+    let (success, filename_used): (bool, String) = response.body().deserialize()?;
+
+    if success {
+        Ok(format!("Screenshot taken. File saved to: {filename_used}"))
+    } else {
+        Err(anyhow::anyhow!("GNOME Shell screenshot failed"))
+    }
+}
+
+async fn take_interactive_screenshot_shell() -> Result<String> {
+    let connection = zbus::Connection::session().await?;
+    let proxy = zbus::Proxy::new(
+        &connection,
+        "org.gnome.Shell.Screenshot",
+        "/org/gnome/Shell/Screenshot",
+        "org.gnome.Shell.Screenshot",
+    )
+    .await?;
+
+    let response = proxy.call_method("InteractiveScreenshot", &()).await?;
+    let (success, uri): (bool, String) = response.body().deserialize()?;
+
+    if success {
+        Ok(format!(
+            "Interactive screenshot completed. File saved to: {uri}"
+        ))
+    } else {
+        Err(anyhow::anyhow!("GNOME Shell interactive screenshot failed"))
     }
 }

--- a/src/tools/window_management.rs
+++ b/src/tools/window_management.rs
@@ -125,6 +125,14 @@ async fn execute_window_action(params: WindowManagementParams) -> Result<String>
 
 async fn list_windows(shell_proxy: &zbus::Proxy<'_>) -> Result<String> {
     let script = r#"
+        function isMaximized(w) {
+            if (typeof w.get_maximized === 'function') {
+                return Boolean(w.get_maximized());
+            }
+
+            return Boolean(w.maximized_horizontally && w.maximized_vertically);
+        }
+
         let windows = global.get_window_actors()
             .map(w => w.get_meta_window())
             .filter(w => w.get_window_type() === Meta.WindowType.NORMAL && !w.is_skip_taskbar())
@@ -134,7 +142,7 @@ async fn list_windows(shell_proxy: &zbus::Proxy<'_>) -> Result<String> {
                 wm_class: w.get_wm_class(),
                 workspace: w.get_workspace().index(),
                 minimized: w.minimized,
-                maximized: w.get_maximized(),
+                maximized: isMaximized(w),
                 focused: w.has_focus()
             }));
         JSON.stringify(windows);
@@ -211,12 +219,20 @@ async fn minimize_window(shell_proxy: &zbus::Proxy<'_>, window_id: &str) -> Resu
 async fn maximize_window(shell_proxy: &zbus::Proxy<'_>, window_id: &str) -> Result<String> {
     let script = format!(
         r#"
+        function isMaximized(w) {{
+            if (typeof w.get_maximized === 'function') {{
+                return Boolean(w.get_maximized());
+            }}
+
+            return Boolean(w.maximized_horizontally && w.maximized_vertically);
+        }}
+
         let windows = global.get_window_actors()
             .map(w => w.get_meta_window())
             .filter(w => w.get_id() === {window_id});
         if (windows.length > 0) {{
             let window = windows[0];
-            if (window.get_maximized()) {{
+            if (isMaximized(window)) {{
                 window.unmaximize(Meta.MaximizeFlags.BOTH);
                 'unmaximized';
             }} else {{


### PR DESCRIPTION
I needed to take some screenshots for app metadata and the mcp server wasn't working in GNOME Shell 50 under OpenAI Codex. This PR fixes it for me, there may well be changes you don't like (e.g. hitting dbus directly as a fallback) and I've not tested this again on a pre-50 version so this is *extremely* yolo.